### PR TITLE
Add shadeless color support

### DIFF
--- a/blb_processor.py
+++ b/blb_processor.py
@@ -2422,6 +2422,7 @@ def __process_mesh_data(context, properties, bounds_data, mesh_objects, forward_
         vertex_color_alpha = None
 
         logger.info("Exporting object: {}".format(object_name), 1)
+        shadeless_materials = {}
 
         # PROCESS TOKENS
 
@@ -2665,9 +2666,16 @@ def __process_mesh_data(context, properties, bounds_data, mesh_objects, forward_
                     tokens = __split_object_string_to_tokens(material.name)
                     shadeless = material.use_shadeless
 
-                    rcolor = material.diffuse_color.r + 1 if shadeless else material.diffuse_color.r
-                    gcolor = material.diffuse_color.g + 1 if shadeless else material.diffuse_color.g
-                    bcolor = material.diffuse_color.b + 1 if shadeless else material.diffuse_color.b
+                    def get_shadeless_color(val):
+                        return val + 1 if val >= 0.5 else val
+
+                    rcolor = get_shadeless_color(material.diffuse_color.r) if shadeless else material.diffuse_color.r
+                    gcolor = get_shadeless_color(material.diffuse_color.g) if shadeless else material.diffuse_color.g
+                    bcolor = get_shadeless_color(material.diffuse_color.b) if shadeless else material.diffuse_color.b
+
+                    if shadeless and shadeless_materials.get(material.name, None) is None:
+                        shadeless_materials[material.name] = str((rcolor, gcolor, bcolor))
+                        logger.info("Exporting shadeless color material {}.".format(shadeless_materials[material.name]), 2)
 
                     if material is not None:
                         if properties.deftokens.color_add in tokens:

--- a/blb_processor.py
+++ b/blb_processor.py
@@ -2663,21 +2663,26 @@ def __process_mesh_data(context, properties, bounds_data, mesh_objects, forward_
                 if len(obj.material_slots) > 0:
                     material = obj.material_slots[poly.material_index].material
                     tokens = __split_object_string_to_tokens(material.name)
+                    shadeless = material.use_shadeless
+
+                    rcolor = material.diffuse_color.r + 1 if shadeless else material.diffuse_color.r
+                    gcolor = material.diffuse_color.g + 1 if shadeless else material.diffuse_color.g
+                    bcolor = material.diffuse_color.b + 1 if shadeless else material.diffuse_color.b
 
                     if material is not None:
                         if properties.deftokens.color_add in tokens:
                             # Negative alpha.
-                            colors = ([(material.diffuse_color.r, material.diffuse_color.g, material.diffuse_color.b, -material.alpha)] * 4)
+                            colors = ([(rcolor, gcolor, bcolor, -material.alpha)] * 4)
                         elif properties.deftokens.color_sub in tokens:
                             # Negative everything.
-                            colors = ([(-material.diffuse_color.r, -material.diffuse_color.g, -material.diffuse_color.b, -material.alpha)] * 4)
+                            colors = ([(-rcolor, -gcolor, -bcolor, -material.alpha)] * 4)
                         elif properties.deftokens.color_blank in tokens:
                             # If the material name is "blank", use the spray can color by not defining any color for this quad.
                             # This is how quads that can change color (by colorshifting) in DTS meshes (which Blockland uses) are defined.
                             colors = None
                         else:
                             # 4 vertices per quad.
-                            colors = ([(material.diffuse_color.r, material.diffuse_color.g, material.diffuse_color.b, material.alpha)] * 4)
+                            colors = ([(rcolor, gcolor, bcolor, material.alpha)] * 4)
 
             # =============
             # Vertex Colors


### PR DESCRIPTION
Shadeless/glowing colors on bricks can be done in .blb's manually by using color values between 1.000 to 2.000, as seen on the default Christmas Tree brick. This change automatically exports materials with "shadeless" ticked on as glowing.